### PR TITLE
Fix mixed content error.

### DIFF
--- a/static/css/main.css
+++ b/static/css/main.css
@@ -1,4 +1,4 @@
-@import url("http://fonts.googleapis.com/css?family=Source+Sans+Pro:300,300italic,600,600italic");
+@import url("https://fonts.googleapis.com/css?family=Source+Sans+Pro:300,300italic,600,600italic");
 /*
 	Arcana by HTML5 UP
 	html5up.net | @n33co


### PR DESCRIPTION
A browser will produce an error for the user showing the site as insecure because of mixed content. This fix will correct the issue.